### PR TITLE
Add standalone fix for Issue 33

### DIFF
--- a/controls/V-73533.rb
+++ b/controls/V-73533.rb
@@ -41,10 +41,11 @@ control 'V-73533' do
     impact 0.0
     desc 'This system is a domain controller, therefore this control is not applicable as it only applies to member servers and standalone systems'
   end
-  
+
   if domain_role == '2'
     impact 0.0
-    desc 'This system is not a member of a domain, therefore this control is not applicable as it only applies to member servers'
+    describe 'This system is not joined to a domain, therfore this control is not appliable as it does not apply to standalone systems' do
       skip 'This system is not joined to a domain, therfore this control is not appliable as it does not apply to standalone systems'
+    end
   end
 end

--- a/controls/V-73533.rb
+++ b/controls/V-73533.rb
@@ -44,6 +44,7 @@ control 'V-73533' do
   
   if domain_role == '2'
     impact 0.0
-    desc 'This system is not a member of a domain, therefore this control is not applicable as it only applies to member servers' 
+    desc 'This system is not a member of a domain, therefore this control is not applicable as it only applies to member servers'
+      skip 'This system is not joined to a domain, therfore this control is not appliable as it does not apply to standalone systems'
   end
 end

--- a/controls/V-73533.rb
+++ b/controls/V-73533.rb
@@ -29,6 +29,7 @@ control 'V-73533' do
   Administrative Templates >> System >> Logon >> Enumerate local users on
   domain-joined computers to Disabled."
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
+  member_of_domain = command('(gwmi win32_computersystem).partofdomain').stdout.strip
 
   if !(domain_role == '4') && !(domain_role == '5')
     describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\System') do
@@ -40,5 +41,10 @@ control 'V-73533' do
   if domain_role == '4' || domain_role == '5'
     impact 0.0
     desc 'This system is a domain controller, therefore this control is not applicable as it only applies to member servers and standalone systems'
+  end
+  
+  if member_of_domain == 'False'
+    impact 0.0
+    desc 'This system is not a member of a domain, therefore this control is not applicable as it only applies to member servers' 
   end
 end

--- a/controls/V-73533.rb
+++ b/controls/V-73533.rb
@@ -29,9 +29,8 @@ control 'V-73533' do
   Administrative Templates >> System >> Logon >> Enumerate local users on
   domain-joined computers to Disabled."
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  member_of_domain = command('(gwmi win32_computersystem).partofdomain').stdout.strip
 
-  if !(domain_role == '4') && !(domain_role == '5')
+  if !(domain_role == '4') && !(domain_role == '5') && !(domain_role == '2')
     describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\System') do
       it { should have_property 'EnumerateLocalUsers' }
       its('EnumerateLocalUsers') { should cmp 0 }
@@ -43,7 +42,7 @@ control 'V-73533' do
     desc 'This system is a domain controller, therefore this control is not applicable as it only applies to member servers and standalone systems'
   end
   
-  if member_of_domain == 'False'
+  if domain_role == '2'
     impact 0.0
     desc 'This system is not a member of a domain, therefore this control is not applicable as it only applies to member servers' 
   end


### PR DESCRIPTION
Looked at the wmi return values further and found that a non-domain joined system will return a 2. Using this vs getting a new var.

https://github.com/mitre/microsoft-windows-server-2016-stig-baseline/issues/33