### PR TITLE
Issue #40 v 73387 hardcodes domain

### DIFF
--- a/controls/V-73387.rb
+++ b/controls/V-73387.rb
@@ -81,7 +81,7 @@ control 'V-73387' do
   forrest = attribute('forrest')
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
   if domain_role == '4' || domain_role == '5'
-    query = command("dsquery * \"cn=Default Query Policy,cn=Query-Policies,cn=Directory Service, cn=Windows NT,cn=Services,cn=Configuration,dc=testdomain,dc=com\" -attr LDAPAdminLimits").stdout
+    query = command("dsquery * \"cn=Default Query Policy,cn=Query-Policies,cn=Directory Service, cn=Windows NT,cn=Services,cn=Configuration," + forrest + "\" -attr LDAPAdminLimits").stdout
     ldap_admin_limits = parse_config(query.gsub(/;/, "\n")).params
     describe "MaxConnIdleTime is configured" do
       subject { ldap_admin_limits }


### PR DESCRIPTION
Issue #40 
V-73387 has the domain hardcoded to testdomain.com. This PR replaces the hardcoded testdomain with the `forrest` input. 