### PR TITLE
Issue #41 - V-73307 Fails on Domain Controller with PDC Emulator Role

### DIFF
--- a/controls/V-73307.rb
+++ b/controls/V-73307.rb
@@ -65,7 +65,6 @@ control 'V-73307' do
       end
     else
       impact 0.0
-      desc 'This system is a domain controller with the PDC Emulator role, therefore this control is not applicable.'
       describe 'This system is a domain controller with the PDC Emulator role, therefore this control is not applicable.' do
         skip 'This system is a domain controller with the PDC Emulator role, therefore this control is not applicable.'
       end


### PR DESCRIPTION
Issue #41 V-73307 Fails on Domain Controller with PDC Emulator Role
Domain Controllers with the PDC Emulator Role are exempt from V-73307.  This PR check for the PDC Emulator Role and then evaluates if the target holds that role. The STIG identifies a PowerShell commands to determine the PDC Emulator, but I haven't seen PowerShell used elsewhere in the code base, and I feel like I've seen PowerShell disabled on certain systems. 
