### PR TITLE
Issue #46 - V-73391 Excessive Iterations

### DIFF
--- a/controls/V-73391.rb
+++ b/controls/V-73391.rb
@@ -149,8 +149,8 @@ control 'V-73391' do
       acl_rules = [JSON.parse(acl_rules.to_json)]
     end
 
-    describe.one do
-      acl_rules.each do |acl_rule|
+    acl_rules.each do |acl_rule|
+      describe.one do
         describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
           subject { acl_rule }
           its(['AuditFlags']) { should cmp "Fail" }
@@ -160,11 +160,7 @@ control 'V-73391' do
           its(['InheritanceType']) { should cmp "None" }
           its(['PropagationFlags']) { should cmp "None" }
         end
-      end
-    end
 
-    describe.one do
-      acl_rules.each do |acl_rule|
         describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
           subject { acl_rule }
           its(['AuditFlags']) { should cmp "Success" }
@@ -174,11 +170,7 @@ control 'V-73391' do
           its(['InheritanceType']) { should cmp "All" }
           its(['PropagationFlags']) { should cmp "None" }
         end
-      end
-    end
 
-    describe.one do
-      acl_rules.each do |acl_rule|
         describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
           subject { acl_rule }
           its(['AuditFlags']) { should cmp "Success" }
@@ -188,11 +180,7 @@ control 'V-73391' do
           its(['InheritanceType']) { should cmp "None" }
           its(['PropagationFlags']) { should cmp "None" }
         end
-      end
-    end
 
-    describe.one do
-      acl_rules.each do |acl_rule|
         describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
           subject { acl_rule }
           its(['AuditFlags']) { should cmp "Success" }
@@ -202,11 +190,7 @@ control 'V-73391' do
           its(['InheritanceType']) { should cmp "None" }
           its(['PropagationFlags']) { should cmp "None" }
         end
-      end
-    end
 
-    describe.one do
-      acl_rules.each do |acl_rule|
         describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
           subject { acl_rule }
           its(['AuditFlags']) { should cmp "Success" }


### PR DESCRIPTION
Issue #46 
V-73391 performs excessive iterations due to `describe.one` blocks around each describe blocks. Within each `describe.one` block it also iterates across each acl_rule.  

This PR reduces the `describe.one` blocks to a single block that encapsulates all five describe sets. It also moves the `acl_rules` loop outside of the describe.one block.  This results in each rule being evaluated to match one describe set in the `describe.one` block.