### PR TITLE
Issue #48 - V-73389 Excessive Iterations

### DIFF
--- a/controls/V-73389.rb
+++ b/controls/V-73389.rb
@@ -133,19 +133,15 @@ control 'V-73389' do
         acl_rules = [JSON.parse(acl_rules.to_json)]
       end
 
-      describe.one do
-        acl_rules.each do |acl_rule|
+      acl_rules.each do |acl_rule|
+        describe.one do
           describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
             subject { acl_rule }
             its(['AuditFlags']) { should cmp "Fail" }
             its(['IdentityReference']) { should cmp "Everyone" }
             its(['ActiveDirectoryRights']) { should cmp /(GenericAll)/ }
           end
-        end
-      end
 
-      describe.one do
-        acl_rules.each do |acl_rule|
           describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
             subject { acl_rule }
             its(['AuditFlags']) { should cmp "Success" }
@@ -154,11 +150,7 @@ control 'V-73389' do
             its(['IsInherited']) { should cmp "True" }
             its(['InheritanceType']) { should cmp "All" }
           end
-        end
-      end
 
-      describe.one do
-        acl_rules.each do |acl_rule|
           describe "Audit rule property for principal: #{acl_rule['IdentityReference']}" do
             subject { acl_rule }
             its(['AuditFlags']) { should cmp "Success" }


### PR DESCRIPTION
Issue #48 
V-73389 performs excessive iterations due to describe.one blocks around each describe blocks. Within each describe.one block it also iterates across each acl_rule.

This PR reduces the describe.one blocks to a single block that encapsulates all five describe sets. It also moves the acl_rules loop outside of the describe.one block. This results in each rule being evaluated to match one describe set in the describe.one block.