### PR TITLE
Changed matcher in V-73651 to accurately compare with registry value.

### DIFF
--- a/controls/V-73651.rb
+++ b/controls/V-73651.rb
@@ -37,7 +37,7 @@ control 'V-73651' do
   if !(domain_role == '4') && !(domain_role == '5')
     describe registry_key('HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon') do
       it { should have_property 'CachedLogonsCount' }
-      its('CachedLogonsCount') { should be <= 4 }
+      its('CachedLogonsCount') { should cmp <= 4 }
     end
   end
 


### PR DESCRIPTION
When using the existing V-73651 control code, my scans failed even though my HKEY_LOCAL_MACHINE \\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\CachedLogonsCount was equal to 4. I changed the matcher from 

  'should be <= 4' 

to 

  'should cmp <= 4' 

and the control now passes as expected.