### PR TITLE
fixed v-73533 by adding missing end

### DIFF
--- a/controls/V-73533.rb
+++ b/controls/V-73533.rb
@@ -39,5 +39,6 @@ control 'V-73533' do
     impact 0.0
     describe 'This control is not applicable as it only applies to member servers' do
       skip 'This control is not applicable as it only applies to member servers'
+    end
   end
 end


### PR DESCRIPTION
Modified v-73533 to fix ./controls/V-73533.rb:43: syntax error, unexpected end-of-input, expecting `end' (SyntaxError)